### PR TITLE
Fix/vt addbatch

### DIFF
--- a/tree.go
+++ b/tree.go
@@ -478,7 +478,7 @@ func newLeafValue(hashFunc HashFunction, k, v []byte) ([]byte, []byte, error) {
 		return nil, nil, err
 	}
 	var leafValue []byte
-	leafValue = append(leafValue, byte(1))
+	leafValue = append(leafValue, byte(PrefixValueLeaf))
 	leafValue = append(leafValue, byte(len(k)))
 	leafValue = append(leafValue, k...)
 	leafValue = append(leafValue, v...)
@@ -509,11 +509,11 @@ func (t *Tree) newIntermediate(l, r []byte) ([]byte, []byte, error) {
 // computes its hash. Returns the hash of the node, which is the node key, and a
 // byte array that contains the value (which contains the left & right child
 // keys) to store in the DB.
-// [     1 byte   |     1 byte    | N bytes  |  N bytes  ]
-// [ type of node | length of key | left key | right key ]
+// [     1 byte   |     1 byte         | N bytes  |  N bytes  ]
+// [ type of node | length of left key | left key | right key ]
 func newIntermediate(hashFunc HashFunction, l, r []byte) ([]byte, []byte, error) {
 	b := make([]byte, PrefixValueLen+hashFunc.Len()*2)
-	b[0] = 2
+	b[0] = PrefixValueIntermediate
 	b[1] = byte(len(l))
 	copy(b[PrefixValueLen:PrefixValueLen+hashFunc.Len()], l)
 	copy(b[PrefixValueLen+hashFunc.Len():], r)

--- a/vt.go
+++ b/vt.go
@@ -173,7 +173,7 @@ func (t *vt) addBatch(ks, vs [][]byte) ([]int, error) {
 	wg.Add(nCPU)
 	for i := 0; i < nCPU; i++ {
 		go func(cpu int) {
-			bucketVT := newVT(t.params.maxLevels-l, t.params.hashFunction)
+			bucketVT := newVT(t.params.maxLevels, t.params.hashFunction)
 			bucketVT.root = nodesAtL[cpu]
 			for j := 0; j < len(buckets[cpu]); j++ {
 				if err = bucketVT.add(l, buckets[cpu][j].k, buckets[cpu][j].v); err != nil {

--- a/vt_test.go
+++ b/vt_test.go
@@ -143,6 +143,30 @@ func TestVirtualTreeAddBatch(t *testing.T) {
 	c.Assert(vTree.root.h, qt.DeepEquals, root)
 }
 
+func TestVirtualTreeAddBatchFullyUsed(t *testing.T) {
+	c := qt.New(t)
+
+	vTree1 := newVT(7, HashFunctionPoseidon) // used for add one by one
+	vTree2 := newVT(7, HashFunctionPoseidon) // used for addBatch
+
+	var keys, values [][]byte
+	for i := 0; i < 128; i++ {
+		k := BigIntToBytes(32, big.NewInt(int64(i)))
+		v := k
+
+		keys = append(keys, k)
+		values = append(values, v)
+
+		// add one by one expecting no error
+		err := vTree1.add(0, k, v)
+		c.Assert(err, qt.IsNil)
+	}
+
+	invalids, err := vTree2.addBatch(keys, values)
+	c.Assert(err, qt.IsNil)
+	c.Assert(0, qt.Equals, len(invalids))
+}
+
 func TestGetNodesAtLevel(t *testing.T) {
 	c := qt.New(t)
 


### PR DESCRIPTION
- Fix VirtualTree.addBatch bucket levels
- Use Prefix consts instead of hardcoded values in newLeafValue & newIntermediate methods