### PR TITLE
Fix level when going down & in computeHashes

### DIFF
--- a/tree.go
+++ b/tree.go
@@ -340,7 +340,7 @@ func (t *Tree) add(wTx db.WriteTx, root []byte, fromLvl int, k, v []byte) ([]byt
 func (t *Tree) down(rTx db.ReadTx, newKey, currKey []byte, siblings [][]byte,
 	path []bool, currLvl int, getLeaf bool) (
 	[]byte, []byte, [][]byte, error) {
-	if currLvl > t.maxLevels-1 {
+	if currLvl > t.maxLevels {
 		return nil, nil, nil, ErrMaxLevel
 	}
 

--- a/vt.go
+++ b/vt.go
@@ -318,11 +318,11 @@ func (t *vt) computeHashes() ([][2][]byte, error) {
 	wg.Add(nCPU)
 	for i := 0; i < nCPU; i++ {
 		go func(cpu int) {
-			bucketVT := newVT(t.params.maxLevels-l, t.params.hashFunction)
+			bucketVT := newVT(t.params.maxLevels, t.params.hashFunction)
 			bucketVT.params.dbg = newDbgStats()
 			bucketVT.root = nodesAtL[cpu]
 
-			bucketPairs[cpu], err = bucketVT.root.computeHashes(l,
+			bucketPairs[cpu], err = bucketVT.root.computeHashes(l-1,
 				t.params.maxLevels, bucketVT.params, bucketPairs[cpu])
 			if err != nil {
 				errs[cpu] = err


### PR DESCRIPTION
Fix level when going down & in computeHashes, this affected the methods Get, GenProof & AddBatch.