### PR TITLE
Update VT goroutines errs & Update Pack&UnpackSibl

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 err-dump
+covprofile

--- a/tree_test.go
+++ b/tree_test.go
@@ -311,7 +311,7 @@ func TestGenProofAndVerify(t *testing.T) {
 	c.Assert(err, qt.IsNil)
 	defer tree.db.Close() //nolint:errcheck
 
-	bLen := tree.HashFunction().Len()
+	bLen := tree.HashFunction().Len() - 1
 	for i := 0; i < 10; i++ {
 		k := BigIntToBytes(bLen, big.NewInt(int64(i)))
 		v := BigIntToBytes(bLen, big.NewInt(int64(i*2)))

--- a/vt.go
+++ b/vt.go
@@ -176,7 +176,7 @@ func (t *vt) addBatch(ks, vs [][]byte) ([]int, error) {
 			bucketVT := newVT(t.params.maxLevels, t.params.hashFunction)
 			bucketVT.root = nodesAtL[cpu]
 			for j := 0; j < len(buckets[cpu]); j++ {
-				if err = bucketVT.add(l, buckets[cpu][j].k, buckets[cpu][j].v); err != nil {
+				if err := bucketVT.add(l, buckets[cpu][j].k, buckets[cpu][j].v); err != nil {
 					invalidsInBucket[cpu] = append(invalidsInBucket[cpu], buckets[cpu][j].pos)
 				}
 			}
@@ -321,7 +321,7 @@ func (t *vt) computeHashes() ([][2][]byte, error) {
 			bucketVT := newVT(t.params.maxLevels, t.params.hashFunction)
 			bucketVT.params.dbg = newDbgStats()
 			bucketVT.root = nodesAtL[cpu]
-
+			var err error
 			bucketPairs[cpu], err = bucketVT.root.computeHashes(l-1,
 				t.params.maxLevels, bucketVT.params, bucketPairs[cpu])
 			if err != nil {


### PR DESCRIPTION
- Update VT goroutines errs to avoid race condition
- ~Add missing RLocks~
- Update pack & unpack siblings to use 2-byte for full length & bitmap bytes length
- Add check in UnpackSiblings to avoid panic