### PR TITLE
fix HashBigInts() append

### DIFF
--- a/tree_big.go
+++ b/tree_big.go
@@ -269,12 +269,12 @@ func bigIntsToLeaf(hFn HashFunction, keyLen int, key *big.Int, bigints []*big.In
 // using the hash function of the tree. The resulting hash can be used as the leaf value
 func HashBigInts(hFn HashFunction, values ...*big.Int) ([]byte, error) {
 	chunks := make([][]byte, len(values))
-	for _, v := range values {
+	for i, v := range values {
 		value := hFn.SafeBigInt(v)
 		if value == nil {
 			return nil, fmt.Errorf("value cannot be nil")
 		}
-		chunks = append(chunks, value)
+		chunks[i] = value
 	}
 	return hFn.Hash(chunks...)
 }


### PR DESCRIPTION
Since HashBigInts() was initializing the slice and then appending, the content of chunks was not i.e
[1,2,3] but [0,0,0,1,2,3].
Use the index on the loop and assign values w/o append.