### PR TITLE
feat(tree): add BigInt WithTx wrappers

### DIFF
--- a/tree.go
+++ b/tree.go
@@ -127,7 +127,7 @@ type Config struct {
 // NewTree returns a new Tree, if there is a Tree still in the given database, it
 // will load it.
 func NewTree(cfg Config) (*Tree, error) {
-	wTx := prefixeddb.NewPrefixedWriteTx(cfg.Database.WriteTx(), dbTreePrefix)
+	wTx := NewTreeWriteTx(cfg.Database)
 	defer wTx.Discard()
 
 	t, err := NewTreeWithTx(wTx, cfg)
@@ -141,8 +141,15 @@ func NewTree(cfg Config) (*Tree, error) {
 	return t, nil
 }
 
+// NewTreeWriteTx returns a write transaction scoped to arbo's persisted tree
+// namespace. The caller is responsible for committing or discarding the
+// returned transaction.
+func NewTreeWriteTx(database db.Database) db.WriteTx {
+	return prefixeddb.NewPrefixedWriteTx(database.WriteTx(), dbTreePrefix)
+}
+
 // NewTreeWithTx returns a new Tree using the given db.WriteTx, which will not
-// be ccommited inside this method, if there is a Tree still in the given
+// be committed inside this method. If there is a Tree still in the given
 // database, it will load it.
 func NewTreeWithTx(wTx db.WriteTx, cfg Config) (*Tree, error) {
 	// if thresholdNLeafs is set to 0, use the DefaultThresholdNLeafs
@@ -1220,6 +1227,13 @@ func (t *Tree) RootExists(root []byte) error {
 // Database returns the db.Database used by the Tree
 func (t *Tree) Database() db.Database {
 	return t.treedb
+}
+
+// WriteTx returns a write transaction scoped to this Tree's persisted
+// namespace. The caller is responsible for committing or discarding the
+// returned transaction.
+func (t *Tree) WriteTx() db.WriteTx {
+	return t.treedb.WriteTx()
 }
 
 // Snapshot returns a read-only copy of the Tree from the given root

--- a/tree.go
+++ b/tree.go
@@ -1260,6 +1260,7 @@ func (t *Tree) Snapshot(fromRoot []byte) (*Tree, error) {
 
 	return &Tree{
 		treedb:       t.treedb,
+		valuesdb:     t.valuesdb,
 		maxLevels:    t.maxLevels,
 		snapshotRoot: fromRoot,
 		emptyHash:    t.emptyHash,

--- a/tree_big.go
+++ b/tree_big.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"math/big"
 	"slices"
+
+	"github.com/vocdoni/davinci-node/db"
 )
 
 // AddBatchBigInt adds a batch of key-value pairs to the tree, it converts the
@@ -13,10 +15,24 @@ import (
 // creates a transaction to store the full values in the valuesdb. It returns
 // a slice of Invalid items and an error if something fails.
 func (t *Tree) AddBatchBigInt(keys []*big.Int, bigintsBatch [][]*big.Int) ([]Invalid, error) {
+	wTx := t.treedb.WriteTx()
+	defer wTx.Discard()
+
+	invalids, err := t.AddBatchBigIntWithTx(wTx, keys, bigintsBatch)
+	if err != nil {
+		return invalids, err
+	}
+
+	return invalids, wTx.Commit()
+}
+
+// AddBatchBigIntWithTx does the same than AddBatchBigInt, but allowing to pass
+// the db.WriteTx that is used for the tree. The db.WriteTx will not be
+// committed inside this method.
+func (t *Tree) AddBatchBigIntWithTx(wTx db.WriteTx, keys []*big.Int, bigintsBatch [][]*big.Int) ([]Invalid, error) {
 	if len(keys) != len(bigintsBatch) {
 		return nil, fmt.Errorf("the number of keys and values missmatch")
 	}
-	// convert each key-value tuple into bytes
 	var err error
 	bKeys := make([][]byte, len(keys))
 	bValues := make([][]byte, len(keys))
@@ -27,24 +43,21 @@ func (t *Tree) AddBatchBigInt(keys []*big.Int, bigintsBatch [][]*big.Int) ([]Inv
 			return nil, err
 		}
 	}
-	// acquire lock to make an atomic update to treedb and valuesdb
 	t.valuesdbMu.Lock()
 	defer t.valuesdbMu.Unlock()
-	// add the keys and leaf values in batch
-	if invalids, err := t.AddBatch(bKeys, bValues); err != nil {
+	invalids, err := t.AddBatchWithTx(wTx, bKeys, bValues)
+	if err != nil {
 		return invalids, err
 	}
-	// create a transaction for each group of keys and serialized values and store
-	// the errors in a slice to return them
-	var invalids []Invalid
-	wTx := t.valuesdb.WriteTx()
-	defer wTx.Discard()
+	var valueInvalids []Invalid
+	vTx := t.valuesdb.WriteTx()
+	defer vTx.Discard()
 	for i := range bKeys {
-		if err := wTx.Set(bValues[i], serializedBigIntsBatch[i]); err != nil {
-			invalids = append(invalids, Invalid{i, err})
+		if err := vTx.Set(bValues[i], serializedBigIntsBatch[i]); err != nil {
+			valueInvalids = append(valueInvalids, Invalid{i, err})
 		}
 	}
-	return invalids, wTx.Commit()
+	return append(invalids, valueInvalids...), vTx.Commit()
 }
 
 // AddBigInt adds a key-value pair to the tree, it converts the big.Int key
@@ -53,29 +66,38 @@ func (t *Tree) AddBatchBigInt(keys []*big.Int, bigintsBatch [][]*big.Int) ([]Inv
 // transaction to store the serialized bigints in the valuesdb. It returns an error if
 // something fails.
 func (t *Tree) AddBigInt(key *big.Int, bigints ...*big.Int) error {
+	wTx := t.treedb.WriteTx()
+	defer wTx.Discard()
+
+	if err := t.AddBigIntWithTx(wTx, key, bigints...); err != nil {
+		return err
+	}
+
+	return wTx.Commit()
+}
+
+// AddBigIntWithTx does the same than AddBigInt, but allowing to pass the
+// db.WriteTx that is used for the tree. The db.WriteTx will not be committed
+// inside this method.
+func (t *Tree) AddBigIntWithTx(wTx db.WriteTx, key *big.Int, bigints ...*big.Int) error {
 	if key == nil {
 		return fmt.Errorf("key cannot be nil")
 	}
-	// convert the big ints to bytes
 	bKey, bValue, serializedBigInts, err := bigIntsToLeaf(t.HashFunction(), t.MaxKeyLen(), key, bigints)
 	if err != nil {
 		return err
 	}
-	// acquire lock to make an atomic update to treedb and valuesdb
 	t.valuesdbMu.Lock()
 	defer t.valuesdbMu.Unlock()
-	// add it to the tree
-	if err := t.Add(bKey, bValue); err != nil {
+	if err := t.AddWithTx(wTx, bKey, bValue); err != nil {
 		return fmt.Errorf("raw key cannot be added: %w", err)
 	}
-	// create a transaction to store the serialized bigints
-	wTx := t.valuesdb.WriteTx()
-	defer wTx.Discard()
-	// store the serialized bigints in the valuesdb
-	if err := wTx.Set(bValue, serializedBigInts); err != nil {
+	vTx := t.valuesdb.WriteTx()
+	defer vTx.Discard()
+	if err := vTx.Set(bValue, serializedBigInts); err != nil {
 		return fmt.Errorf("serializedBigInts cannot be stored: %w", err)
 	}
-	return wTx.Commit()
+	return vTx.Commit()
 }
 
 // UpdateBigInt updates the value of a key as a big.Int and the values of the
@@ -83,29 +105,38 @@ func (t *Tree) AddBigInt(key *big.Int, bigints ...*big.Int) error {
 // the leaf node in the tree, then it stores the full value in the valuesdb. It
 // returns an error if something fails.
 func (t *Tree) UpdateBigInt(key *big.Int, bigints ...*big.Int) error {
+	wTx := t.treedb.WriteTx()
+	defer wTx.Discard()
+
+	if err := t.UpdateBigIntWithTx(wTx, key, bigints...); err != nil {
+		return err
+	}
+
+	return wTx.Commit()
+}
+
+// UpdateBigIntWithTx does the same than UpdateBigInt, but allowing to pass the
+// db.WriteTx that is used for the tree. The db.WriteTx will not be committed
+// inside this method.
+func (t *Tree) UpdateBigIntWithTx(wTx db.WriteTx, key *big.Int, bigints ...*big.Int) error {
 	if key == nil {
 		return fmt.Errorf("key cannot be nil")
 	}
-	// convert the big ints to bytes
 	bKey, bValue, serializedBigInts, err := bigIntsToLeaf(t.HashFunction(), t.MaxKeyLen(), key, bigints)
 	if err != nil {
 		return err
 	}
-	// acquire lock to make an atomic update to treedb and valuesdb
 	t.valuesdbMu.Lock()
 	defer t.valuesdbMu.Unlock()
-	// update the leaf in the tree
-	if err := t.Update(bKey, bValue); err != nil {
+	if err := t.UpdateWithTx(wTx, bKey, bValue); err != nil {
 		return err
 	}
-	// create a transaction to store the serialized bigints
-	wTx := t.valuesdb.WriteTx()
-	defer wTx.Discard()
-	// store the serialized bigints value in the valuesdb
-	if err := wTx.Set(bValue, serializedBigInts); err != nil {
+	vTx := t.valuesdb.WriteTx()
+	defer vTx.Discard()
+	if err := vTx.Set(bValue, serializedBigInts); err != nil {
 		return err
 	}
-	return wTx.Commit()
+	return vTx.Commit()
 }
 
 // GetBigInt receives the value of a key as a big.Int and the values of the leaf
@@ -115,14 +146,24 @@ func (t *Tree) UpdateBigInt(key *big.Int, bigints ...*big.Int) error {
 func (t *Tree) GetBigInt(k *big.Int) (
 	key *big.Int, bigints []*big.Int, err error,
 ) {
-	// acquire lock to wait for atomic updates to treedb and valuesdb to finish
+	return t.GetBigIntWithTx(t.treedb, k)
+}
+
+// GetBigIntWithTx receives the value of a key as a big.Int and the values of
+// the leaf node as a slice of big.Ints. It encodes the key as bytes and gets
+// the leaf node from the tree using the given db.Reader, then it decodes the
+// serialized bigints of the leaf node and returns the key and the values or an
+// error if something fails.
+func (t *Tree) GetBigIntWithTx(rTx db.Reader, k *big.Int) (
+	key *big.Int, bigints []*big.Int, err error,
+) {
 	t.valuesdbMu.RLock()
 	defer t.valuesdbMu.RUnlock()
 	if k == nil {
 		return nil, nil, fmt.Errorf("key cannot be nil")
 	}
 	bk := bigIntToLeafKey(k, t.MaxKeyLen())
-	_, bv, err := t.Get(bk)
+	_, bv, err := t.GetWithTx(rTx, bk)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -140,11 +181,19 @@ func (t *Tree) GetBigInt(k *big.Int) (
 func (t *Tree) GenProofBigInts(key *big.Int) (
 	leafKey []byte, leafValue []byte, siblings []byte, existence bool, err error,
 ) {
+	return t.GenProofBigIntsWithTx(t.treedb, key)
+}
+
+// GenProofBigIntsWithTx generates a proof for a key as a big.Int using the
+// given db.Reader.
+func (t *Tree) GenProofBigIntsWithTx(rTx db.Reader, key *big.Int) (
+	leafKey []byte, leafValue []byte, siblings []byte, existence bool, err error,
+) {
 	if key == nil {
 		return nil, nil, nil, false, fmt.Errorf("key cannot be nil")
 	}
 	bk := bigIntToLeafKey(key, t.MaxKeyLen())
-	return t.GenProof(bk)
+	return t.GenProofWithTx(rTx, bk)
 }
 
 // GenerateCircomVerifierProofBigInt generates a CircomVerifierProof for a key
@@ -152,11 +201,45 @@ func (t *Tree) GenProofBigInts(key *big.Int) (
 // for the key, then it returns the CircomVerifierProof or an error if
 // something fails.
 func (t *Tree) GenerateCircomVerifierProofBigInt(k *big.Int) (*CircomVerifierProof, error) {
+	return t.GenerateCircomVerifierProofBigIntWithTx(t.treedb, k)
+}
+
+// GenerateCircomVerifierProofBigIntWithTx generates a CircomVerifierProof for
+// a key as a big.Int using the given db.Reader.
+func (t *Tree) GenerateCircomVerifierProofBigIntWithTx(rTx db.Reader, k *big.Int) (*CircomVerifierProof, error) {
 	if k == nil {
 		return nil, fmt.Errorf("key cannot be nil")
 	}
-	bk := bigIntToLeafKey(k, t.MaxKeyLen())
-	return t.GenerateCircomVerifierProof(bk)
+	kAux, v, siblings, existence, err := t.GenProofBigIntsWithTx(rTx, k)
+	if err != nil && err != ErrKeyNotFound {
+		return nil, err
+	}
+	var cp CircomVerifierProof
+	cp.Root, err = t.RootWithTx(rTx)
+	if err != nil {
+		return nil, err
+	}
+	s, err := UnpackSiblings(t.hashFunction, siblings)
+	if err != nil {
+		return nil, err
+	}
+	cp.Siblings = t.FillMissingEmptySiblings(s)
+	if !existence {
+		cp.OldKey = kAux
+		cp.OldValue = v
+	} else {
+		cp.OldKey = emptyValue
+		cp.OldValue = emptyValue
+	}
+	cp.Key = bigIntToLeafKey(k, t.MaxKeyLen())
+	cp.Value = v
+	if existence {
+		cp.Fnc = 0
+	} else {
+		cp.Fnc = 1
+	}
+
+	return &cp, nil
 }
 
 // GenerateGnarkVerifierProofBigInt generates a GnarkVerifierProof for a key
@@ -164,11 +247,50 @@ func (t *Tree) GenerateCircomVerifierProofBigInt(k *big.Int) (*CircomVerifierPro
 // for the key, then it returns the GnarkVerifierProof or an error if
 // something fails.
 func (t *Tree) GenerateGnarkVerifierProofBigInt(k *big.Int) (*GnarkVerifierProof, error) {
+	return t.GenerateGnarkVerifierProofBigIntWithTx(t.treedb, k)
+}
+
+// GenerateGnarkVerifierProofBigIntWithTx generates a GnarkVerifierProof for a
+// key as a big.Int using the given db.Reader.
+func (t *Tree) GenerateGnarkVerifierProofBigIntWithTx(rTx db.Reader, k *big.Int) (*GnarkVerifierProof, error) {
 	if k == nil {
 		return nil, fmt.Errorf("key cannot be nil")
 	}
-	bk := bigIntToLeafKey(k, t.MaxKeyLen())
-	return t.GenerateGnarkVerifierProof(bk)
+	oldKey, value, siblings, existence, err := t.GenProofBigIntsWithTx(rTx, k)
+	if err != nil && err != ErrKeyNotFound {
+		return nil, err
+	}
+	root, err := t.RootWithTx(rTx)
+	if err != nil {
+		return nil, err
+	}
+	unpackedSiblings, err := UnpackSiblings(t.hashFunction, siblings)
+	if err != nil {
+		return nil, err
+	}
+	bigSiblings := make([]*big.Int, len(unpackedSiblings))
+	for i := range bigSiblings {
+		bigSiblings[i] = BytesToBigInt(unpackedSiblings[i])
+	}
+	gp := GnarkVerifierProof{
+		Root:     BytesToBigInt(root),
+		Key:      BytesToBigInt(bigIntToLeafKey(k, t.MaxKeyLen())),
+		Value:    BytesToBigInt(value),
+		Siblings: bigSiblings,
+		OldKey:   big.NewInt(0),
+		OldValue: big.NewInt(0),
+		IsOld0:   big.NewInt(0),
+		Fnc:      big.NewInt(0),
+	}
+	if !existence {
+		gp.OldKey = BytesToBigInt(oldKey)
+		gp.OldValue = BytesToBigInt(value)
+		gp.Fnc = big.NewInt(1)
+	}
+	if len(oldKey) == 0 {
+		gp.IsOld0 = big.NewInt(1)
+	}
+	return &gp, nil
 }
 
 // leafToBigInts converts the bytes of the key and the value of a leaf node

--- a/tree_big.go
+++ b/tree_big.go
@@ -7,13 +7,14 @@ import (
 	"slices"
 
 	"github.com/vocdoni/davinci-node/db"
+	"github.com/vocdoni/davinci-node/db/prefixeddb"
 )
 
 // AddBatchBigInt adds a batch of key-value pairs to the tree, it converts the
 // big.Int keys and the slices of big.Int values into bytes and adds them to
 // the tree. It locks the tree to prevent concurrent writes to the valuesdb and
-// creates a transaction to store the full values in the valuesdb. It returns
-// a slice of Invalid items and an error if something fails.
+// stores the full values in the same transaction as the tree. It returns a
+// slice of Invalid items and an error if something fails.
 func (t *Tree) AddBatchBigInt(keys []*big.Int, bigintsBatch [][]*big.Int) ([]Invalid, error) {
 	wTx := t.treedb.WriteTx()
 	defer wTx.Discard()
@@ -50,21 +51,34 @@ func (t *Tree) AddBatchBigIntWithTx(wTx db.WriteTx, keys []*big.Int, bigintsBatc
 		return invalids, err
 	}
 	var valueInvalids []Invalid
-	vTx := t.valuesdb.WriteTx()
-	defer vTx.Discard()
+	var valueErr error
+	invalidIndexes := make(map[int]struct{}, len(invalids))
+	for _, invalid := range invalids {
+		invalidIndexes[invalid.Index] = struct{}{}
+	}
+	vTx := valuesWriteTx(wTx)
 	for i := range bKeys {
+		if _, invalid := invalidIndexes[i]; invalid {
+			continue
+		}
 		if err := vTx.Set(bValues[i], serializedBigIntsBatch[i]); err != nil {
 			valueInvalids = append(valueInvalids, Invalid{i, err})
+			if valueErr == nil {
+				valueErr = err
+			}
 		}
 	}
-	return append(invalids, valueInvalids...), vTx.Commit()
+	if valueErr != nil {
+		return append(invalids, valueInvalids...), fmt.Errorf("serializedBigInts cannot be stored: %w", valueErr)
+	}
+	return append(invalids, valueInvalids...), nil
 }
 
 // AddBigInt adds a key-value pair to the tree, it converts the big.Int key
 // and the slice of big.Int values into bytes and adds them to the tree. It
-// locks the tree to prevent concurrent writes to the valuesdb and creates a
-// transaction to store the serialized bigints in the valuesdb. It returns an error if
-// something fails.
+// locks the tree to prevent concurrent writes to the valuesdb and stores the
+// serialized bigints in the same transaction as the tree. It returns an error
+// if something fails.
 func (t *Tree) AddBigInt(key *big.Int, bigints ...*big.Int) error {
 	wTx := t.treedb.WriteTx()
 	defer wTx.Discard()
@@ -92,12 +106,11 @@ func (t *Tree) AddBigIntWithTx(wTx db.WriteTx, key *big.Int, bigints ...*big.Int
 	if err := t.AddWithTx(wTx, bKey, bValue); err != nil {
 		return fmt.Errorf("raw key cannot be added: %w", err)
 	}
-	vTx := t.valuesdb.WriteTx()
-	defer vTx.Discard()
+	vTx := valuesWriteTx(wTx)
 	if err := vTx.Set(bValue, serializedBigInts); err != nil {
 		return fmt.Errorf("serializedBigInts cannot be stored: %w", err)
 	}
-	return vTx.Commit()
+	return nil
 }
 
 // UpdateBigInt updates the value of a key as a big.Int and the values of the
@@ -131,12 +144,11 @@ func (t *Tree) UpdateBigIntWithTx(wTx db.WriteTx, key *big.Int, bigints ...*big.
 	if err := t.UpdateWithTx(wTx, bKey, bValue); err != nil {
 		return err
 	}
-	vTx := t.valuesdb.WriteTx()
-	defer vTx.Discard()
+	vTx := valuesWriteTx(wTx)
 	if err := vTx.Set(bValue, serializedBigInts); err != nil {
 		return err
 	}
-	return vTx.Commit()
+	return nil
 }
 
 // GetBigInt receives the value of a key as a big.Int and the values of the leaf
@@ -167,11 +179,57 @@ func (t *Tree) GetBigIntWithTx(rTx db.Reader, k *big.Int) (
 	if err != nil {
 		return nil, nil, err
 	}
-	serializedBigInts, err := t.valuesdb.Get(bv)
+	serializedBigInts, err := t.valuesReader(rTx).Get(bv)
 	if err != nil {
 		return nil, nil, err
 	}
 	return t.leafToBigInts(ExplicitZero(bk), bv, serializedBigInts)
+}
+
+type writeTxUnwrapper interface {
+	Unwrap() db.WriteTx
+}
+
+type prefixedWriteTx interface {
+	db.WriteTx
+	Prefix() []byte
+	Unwrap() db.WriteTx
+}
+
+func unwrapWriteTx(wTx db.WriteTx) db.WriteTx {
+	for {
+		unwrapped, ok := wTx.(writeTxUnwrapper)
+		if !ok {
+			return wTx
+		}
+		next := unwrapped.Unwrap()
+		if next == nil || next == wTx {
+			return wTx
+		}
+		wTx = next
+	}
+}
+
+func valuesWriteTx(wTx db.WriteTx) db.WriteTx {
+	if ptx, ok := wTx.(prefixedWriteTx); ok {
+		prefix := ptx.Prefix()
+		if bytes.HasSuffix(prefix, dbTreePrefix) {
+			parentPrefix := prefix[:len(prefix)-len(dbTreePrefix)]
+			valuePrefix := make([]byte, 0, len(parentPrefix)+len(dbValuesPrefix))
+			valuePrefix = append(valuePrefix, parentPrefix...)
+			valuePrefix = append(valuePrefix, dbValuesPrefix...)
+			return prefixeddb.NewPrefixedWriteTx(ptx.Unwrap(), valuePrefix)
+		}
+	}
+	return prefixeddb.NewPrefixedWriteTx(unwrapWriteTx(wTx), dbValuesPrefix)
+}
+
+func (t *Tree) valuesReader(rTx db.Reader) db.Reader {
+	wTx, ok := rTx.(db.WriteTx)
+	if !ok {
+		return t.valuesdb
+	}
+	return valuesWriteTx(wTx)
 }
 
 // GenProofBigInts generates a proof for a key as a big.Int. It converts the

--- a/tree_big_test.go
+++ b/tree_big_test.go
@@ -222,6 +222,97 @@ func TestAddBatchBigInt(t *testing.T) {
 	c.Check(len(invalids), qt.Equals, 0)
 }
 
+func TestBigIntWithTxWrappers(t *testing.T) {
+	c := qt.New(t)
+	tree, err := NewTree(Config{
+		Database:     memdb.New(),
+		MaxLevels:    256,
+		HashFunction: HashFunctionPoseidon,
+	})
+	c.Assert(err, qt.IsNil)
+	defer tree.treedb.Close()   //nolint:errcheck
+	defer tree.valuesdb.Close() //nolint:errcheck
+
+	key := big.NewInt(42)
+	value := big.NewInt(84)
+	wTx := tree.treedb.WriteTx()
+	defer wTx.Discard()
+
+	c.Assert(tree.AddBigIntWithTx(wTx, key, value), qt.IsNil)
+
+	_, _, err = tree.GetBigInt(key)
+	c.Check(err, qt.IsNotNil)
+
+	gotKey, gotValues, err := tree.GetBigIntWithTx(wTx, key)
+	c.Assert(err, qt.IsNil)
+	c.Check(gotKey.Cmp(key), qt.Equals, 0)
+	c.Assert(gotValues, qt.HasLen, 1)
+	c.Check(gotValues[0].Cmp(value), qt.Equals, 0)
+
+	_, _, _, exists, err := tree.GenProofBigIntsWithTx(wTx, key)
+	c.Assert(err, qt.IsNil)
+	c.Check(exists, qt.IsTrue)
+
+	cvp, err := tree.GenerateCircomVerifierProofBigIntWithTx(wTx, key)
+	c.Assert(err, qt.IsNil)
+	c.Check(cvp.Fnc, qt.Equals, 0)
+
+	gp, err := tree.GenerateGnarkVerifierProofBigIntWithTx(wTx, key)
+	c.Assert(err, qt.IsNil)
+	c.Check(gp.Fnc.Cmp(big.NewInt(0)), qt.Equals, 0)
+
+	c.Assert(wTx.Commit(), qt.IsNil)
+
+	gotKey, gotValues, err = tree.GetBigInt(key)
+	c.Assert(err, qt.IsNil)
+	c.Check(gotKey.Cmp(key), qt.Equals, 0)
+	c.Assert(gotValues, qt.HasLen, 1)
+	c.Check(gotValues[0].Cmp(value), qt.Equals, 0)
+
+	newValue := big.NewInt(126)
+	updateTx := tree.treedb.WriteTx()
+	defer updateTx.Discard()
+
+	c.Assert(tree.UpdateBigIntWithTx(updateTx, key, newValue), qt.IsNil)
+
+	gotKey, gotValues, err = tree.GetBigIntWithTx(updateTx, key)
+	c.Assert(err, qt.IsNil)
+	c.Check(gotKey.Cmp(key), qt.Equals, 0)
+	c.Assert(gotValues, qt.HasLen, 1)
+	c.Check(gotValues[0].Cmp(newValue), qt.Equals, 0)
+
+	c.Assert(updateTx.Commit(), qt.IsNil)
+
+	gotKey, gotValues, err = tree.GetBigInt(key)
+	c.Assert(err, qt.IsNil)
+	c.Check(gotKey.Cmp(key), qt.Equals, 0)
+	c.Assert(gotValues, qt.HasLen, 1)
+	c.Check(gotValues[0].Cmp(newValue), qt.Equals, 0)
+
+	batchTx := tree.treedb.WriteTx()
+	defer batchTx.Discard()
+	key2 := big.NewInt(128)
+	value2 := big.NewInt(256)
+	key3 := big.NewInt(129)
+	value3 := big.NewInt(258)
+	invalids, err := tree.AddBatchBigIntWithTx(batchTx,
+		[]*big.Int{key2, key3},
+		[][]*big.Int{{value2}, {value3}},
+	)
+	c.Assert(err, qt.IsNil)
+	c.Check(invalids, qt.HasLen, 0)
+
+	_, batchValues, err := tree.GetBigIntWithTx(batchTx, key2)
+	c.Assert(err, qt.IsNil)
+	c.Assert(batchValues, qt.HasLen, 1)
+	c.Check(batchValues[0].Cmp(value2), qt.Equals, 0)
+
+	_, batchValues, err = tree.GetBigIntWithTx(batchTx, key3)
+	c.Assert(err, qt.IsNil)
+	c.Assert(batchValues, qt.HasLen, 1)
+	c.Check(batchValues[0].Cmp(value3), qt.Equals, 0)
+}
+
 func BenchmarkAddBatchBigInt(b *testing.B) {
 	// Prepare batch data with large random big ints
 	batchSize := 1000

--- a/tree_big_test.go
+++ b/tree_big_test.go
@@ -235,12 +235,16 @@ func TestBigIntWithTxWrappers(t *testing.T) {
 
 	key := big.NewInt(42)
 	value := big.NewInt(84)
+	_, bValue, _, err := bigIntsToLeaf(tree.HashFunction(), tree.MaxKeyLen(), key, []*big.Int{value})
+	c.Assert(err, qt.IsNil)
 	wTx := tree.treedb.WriteTx()
 	defer wTx.Discard()
 
 	c.Assert(tree.AddBigIntWithTx(wTx, key, value), qt.IsNil)
 
 	_, _, err = tree.GetBigInt(key)
+	c.Check(err, qt.IsNotNil)
+	_, err = tree.valuesdb.Get(bValue)
 	c.Check(err, qt.IsNotNil)
 
 	gotKey, gotValues, err := tree.GetBigIntWithTx(wTx, key)
@@ -262,6 +266,9 @@ func TestBigIntWithTxWrappers(t *testing.T) {
 	c.Check(gp.Fnc.Cmp(big.NewInt(0)), qt.Equals, 0)
 
 	c.Assert(wTx.Commit(), qt.IsNil)
+
+	_, err = tree.valuesdb.Get(bValue)
+	c.Check(err, qt.IsNil)
 
 	gotKey, gotValues, err = tree.GetBigInt(key)
 	c.Assert(err, qt.IsNil)
@@ -311,6 +318,88 @@ func TestBigIntWithTxWrappers(t *testing.T) {
 	c.Assert(err, qt.IsNil)
 	c.Assert(batchValues, qt.HasLen, 1)
 	c.Check(batchValues[0].Cmp(value3), qt.Equals, 0)
+}
+
+func TestBigIntWithTxDiscardDoesNotCommitValues(t *testing.T) {
+	c := qt.New(t)
+	tree, err := NewTree(Config{
+		Database:     memdb.New(),
+		MaxLevels:    256,
+		HashFunction: HashFunctionPoseidon,
+	})
+	c.Assert(err, qt.IsNil)
+	defer tree.treedb.Close()   //nolint:errcheck
+	defer tree.valuesdb.Close() //nolint:errcheck
+
+	key := big.NewInt(42)
+	value := big.NewInt(84)
+	_, bValue, _, err := bigIntsToLeaf(tree.HashFunction(), tree.MaxKeyLen(), key, []*big.Int{value})
+	c.Assert(err, qt.IsNil)
+
+	wTx := tree.treedb.WriteTx()
+	c.Assert(tree.AddBigIntWithTx(wTx, key, value), qt.IsNil)
+
+	_, gotValues, err := tree.GetBigIntWithTx(wTx, key)
+	c.Assert(err, qt.IsNil)
+	c.Assert(gotValues, qt.HasLen, 1)
+	c.Check(gotValues[0].Cmp(value), qt.Equals, 0)
+
+	wTx.Discard()
+
+	_, _, err = tree.GetBigInt(key)
+	c.Check(err, qt.IsNotNil)
+	_, err = tree.valuesdb.Get(bValue)
+	c.Check(err, qt.IsNotNil)
+}
+
+func TestAddBatchBigIntWithTxSkipsValuesForInvalidTreeEntries(t *testing.T) {
+	c := qt.New(t)
+	tree, err := NewTree(Config{
+		Database:     memdb.New(),
+		MaxLevels:    256,
+		HashFunction: HashFunctionPoseidon,
+	})
+	c.Assert(err, qt.IsNil)
+	defer tree.treedb.Close()   //nolint:errcheck
+	defer tree.valuesdb.Close() //nolint:errcheck
+
+	key := big.NewInt(42)
+	originalValue := big.NewInt(84)
+	c.Assert(tree.AddBigInt(key, originalValue), qt.IsNil)
+
+	duplicateValue := big.NewInt(168)
+	newKey := big.NewInt(43)
+	newValue := big.NewInt(86)
+	_, duplicateBValue, _, err := bigIntsToLeaf(tree.HashFunction(), tree.MaxKeyLen(), key, []*big.Int{duplicateValue})
+	c.Assert(err, qt.IsNil)
+	_, newBValue, _, err := bigIntsToLeaf(tree.HashFunction(), tree.MaxKeyLen(), newKey, []*big.Int{newValue})
+	c.Assert(err, qt.IsNil)
+
+	wTx := tree.treedb.WriteTx()
+	defer wTx.Discard()
+	invalids, err := tree.AddBatchBigIntWithTx(
+		wTx,
+		[]*big.Int{key, newKey},
+		[][]*big.Int{{duplicateValue}, {newValue}},
+	)
+	c.Assert(err, qt.IsNil)
+	c.Assert(invalids, qt.HasLen, 1)
+	c.Check(invalids[0].Index, qt.Equals, 0)
+	c.Assert(wTx.Commit(), qt.IsNil)
+
+	_, err = tree.valuesdb.Get(duplicateBValue)
+	c.Check(err, qt.IsNotNil)
+	_, err = tree.valuesdb.Get(newBValue)
+	c.Check(err, qt.IsNil)
+
+	_, gotValues, err := tree.GetBigInt(key)
+	c.Assert(err, qt.IsNil)
+	c.Assert(gotValues, qt.HasLen, 1)
+	c.Check(gotValues[0].Cmp(originalValue), qt.Equals, 0)
+	_, gotValues, err = tree.GetBigInt(newKey)
+	c.Assert(err, qt.IsNil)
+	c.Assert(gotValues, qt.HasLen, 1)
+	c.Check(gotValues[0].Cmp(newValue), qt.Equals, 0)
 }
 
 func BenchmarkAddBatchBigInt(b *testing.B) {

--- a/tree_test.go
+++ b/tree_test.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	qt "github.com/frankban/quicktest"
+	"github.com/vocdoni/arbo/memdb"
 	"github.com/vocdoni/davinci-node/db"
 	"github.com/vocdoni/davinci-node/db/pebbledb"
 )
@@ -47,6 +48,76 @@ func testDBTx(c *qt.C, database db.Database) {
 	v, err := wTx.Get([]byte("a"))
 	c.Assert(err, qt.IsNil)
 	c.Assert(v, qt.DeepEquals, []byte("b"))
+}
+
+func TestNewTreeWithTxCanBeDiscardedWithoutInitializingTree(t *testing.T) {
+	c := qt.New(t)
+
+	database := memdb.New()
+	wTx := NewTreeWriteTx(database)
+	_, err := NewTreeWithTx(wTx, Config{
+		Database:     database,
+		MaxLevels:    256,
+		HashFunction: HashFunctionSha256,
+	})
+	c.Assert(err, qt.IsNil)
+	wTx.Discard()
+
+	rawRootKey := append(append([]byte(nil), dbTreePrefix...), dbKeyRoot...)
+	_, err = database.Get(rawRootKey)
+	c.Assert(err, qt.Equals, db.ErrKeyNotFound)
+}
+
+func TestTreeWriteTxUsesTreeNamespace(t *testing.T) {
+	c := qt.New(t)
+
+	database := memdb.New()
+	tree, err := NewTree(Config{
+		Database:     database,
+		MaxLevels:    256,
+		HashFunction: HashFunctionSha256,
+	})
+	c.Assert(err, qt.IsNil)
+
+	wTx := tree.WriteTx()
+	err = wTx.Set(dbKeyRoot, []byte("root-value"))
+	c.Assert(err, qt.IsNil)
+	c.Assert(wTx.Commit(), qt.IsNil)
+	wTx.Discard()
+
+	_, err = database.Get(dbKeyRoot)
+	c.Assert(err, qt.Equals, db.ErrKeyNotFound)
+
+	rawRootKey := append(append([]byte(nil), dbTreePrefix...), dbKeyRoot...)
+	got, err := database.Get(rawRootKey)
+	c.Assert(err, qt.IsNil)
+	c.Assert(got, qt.DeepEquals, []byte("root-value"))
+}
+
+func TestTreeWriteTxWorksWithTreeMethods(t *testing.T) {
+	c := qt.New(t)
+
+	database := memdb.New()
+	tree, err := NewTree(Config{
+		Database:     database,
+		MaxLevels:    256,
+		HashFunction: HashFunctionSha256,
+	})
+	c.Assert(err, qt.IsNil)
+
+	wTx := tree.WriteTx()
+	err = tree.AddWithTx(wTx, []byte{1}, []byte{2})
+	c.Assert(err, qt.IsNil)
+	c.Assert(wTx.Commit(), qt.IsNil)
+	wTx.Discard()
+
+	nLeafs, err := tree.GetNLeafs()
+	c.Assert(err, qt.IsNil)
+	c.Assert(nLeafs, qt.Equals, 1)
+
+	_, gotValue, err := tree.Get([]byte{1})
+	c.Assert(err, qt.IsNil)
+	c.Assert(gotValue, qt.DeepEquals, []byte{2})
 }
 
 func TestAddTestVectors(t *testing.T) {


### PR DESCRIPTION
Keep the BigInt API aligned with the byte API by adding the
missing transaction-aware wrappers and delegating the plain
methods through them.

This preserves the existing storage model while removing the
public API asymmetry around WithTx support.
